### PR TITLE
[CHORE]: Rename GitHub workflow and add workflow badge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: PHP Composer
+name: test
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A very simple package to handle text and image generation from AI tools
 ![PHP Version](https://img.shields.io/badge/php-%3E%3D%208.2-blue.svg)
 ![MIT License Badge](https://img.shields.io/badge/license-MIT-blue)
 ![version](https://img.shields.io/badge/version-v0.1.0-blue)
+![PEST Testing](https://github.com/asciito/simple-generators/actions/workflows/test.yml/badge.svg)
 
 ## Description
 


### PR DESCRIPTION
The GitHub workflow name was changed from "PHP Composer" to "test". Along with this, a badge displaying the workflow status was added to the README file to offer a direct indication of the project's latest build status.