### PR TITLE
[FEAT]: Add image size option

### DIFF
--- a/src/Clients/ClientFake.php
+++ b/src/Clients/ClientFake.php
@@ -17,7 +17,7 @@ class ClientFake implements ClientContract
     }
 
     #[\Override]
-    public function generateImageFromPrompt(string $prompt): string
+    public function generateImageFromPrompt(string $prompt, string $size = null): string
     {
         if (empty($this->imageResponses)) {
             return $this->imageDefaultResponse;

--- a/src/Clients/Contracts/Client.php
+++ b/src/Clients/Contracts/Client.php
@@ -6,7 +6,7 @@ interface Client
 {
     public function __construct(array $options = []);
 
-    public function generateImageFromPrompt(string $prompt): string;
+    public function generateImageFromPrompt(string $prompt, string $size = null): string;
 
     public function generateTextFromPrompt(string $prompt): string;
 

--- a/src/Clients/Exceptions/InvalidImageSize.php
+++ b/src/Clients/Exceptions/InvalidImageSize.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Asciito\SimpleGenerators\Clients\Exceptions;
+
+use Asciito\SimpleGenerators\Clients\Contracts\Exceptions\ClientException;
+
+class InvalidImageSize extends \Exception implements ClientException
+{
+    public function __construct(protected string $clientID, string $message)
+    {
+        parent::__construct("[{$this->clientID}]: ".$message);
+    }
+
+    public static function make(string $client, string $message = ''): static
+    {
+        return new static($client, $message);
+    }
+}

--- a/src/Clients/OpenAI/Client.php
+++ b/src/Clients/OpenAI/Client.php
@@ -3,6 +3,7 @@
 namespace Asciito\SimpleGenerators\Clients\OpenAI;
 
 use Asciito\SimpleGenerators\Clients\Contracts\Client as ClientContract;
+use Asciito\SimpleGenerators\Clients\Exceptions\InvalidImageSize;
 use Illuminate\Support\Collection;
 use OpenAI\Contracts\ClientContract as OpenAIClientContract;
 
@@ -12,6 +13,18 @@ class Client implements ClientContract
 
     protected Collection $options;
 
+    protected array $dallE2ImageSizes = [
+        '256-w' => '256x256',
+        '512-w' => '512x512',
+        '1024-w' => '1024x1024',
+    ];
+
+    protected array $dallE3ImageSizes = [
+        '1024-w' => '1024x1024',
+        '1792-w' => '1792x1024',
+        '1792-h' => '1024x1792',
+    ];
+
     public function __construct(array $options = [], \Closure $clientResolver = null)
     {
         $this->options = collect($options);
@@ -20,13 +33,13 @@ class Client implements ClientContract
     }
 
     #[\Override]
-    public function generateImageFromPrompt(string $prompt): string
+    public function generateImageFromPrompt(string $prompt, string $size = null): string
     {
         $response = $this->resolveClient()->images()->create([
             'model' => $this->getOption('image-model', 'dall-e-3'),
             'prompt' => $prompt,
             'n' => 1,
-            'size' => '1000x1000',
+            'size' => $this->getImageSize($size),
         ]);
 
         return $response->data[0]->url;
@@ -52,6 +65,29 @@ class Client implements ClientContract
     public function getOption(string $key, mixed $value = null): mixed
     {
         return $this->options->get($key, $value);
+    }
+
+    protected function getImageSize(string $size = null): string
+    {
+        $size ??= $this->getOption('image-size', '1024-w');
+        $model = $this->getOption('image-model', 'dall-e-3');
+
+        $sizes = match ($model) {
+            'dall-e-2' => $this->dallE2ImageSizes,
+            'dall-e-3' => $this->dallE3ImageSizes,
+            default => ['1024-w' => '1024x1024'],
+        };
+
+        if (! array_key_exists($size, $sizes)) {
+            $sizes = collect($this->dallE3ImageSizes)
+                ->merge($this->dallE2ImageSizes)
+                ->mapWithKeys(fn ($value, $key) => [$key => "'$key' => '$value'"])
+                ->join(', ');
+
+            throw new InvalidImageSize('open-ai', "The size you try to use [$size] is not valid, the valid sizes are: [$sizes]");
+        }
+
+        return $sizes[$size];
     }
 
     protected function resolveClient(): OpenAIClientContract

--- a/tests/Feature/Clients/OpenAIClientTest.php
+++ b/tests/Feature/Clients/OpenAIClientTest.php
@@ -49,3 +49,10 @@ it('generate an image with Open AI', function () {
         ->not->toBeEmpty()
         ->toBeUrl();
 });
+
+test('invalid image size', function () {
+
+    $openAI = new Client(clientResolver: fn () => new OpenAI\Testing\ClientFake());
+
+    $openAI->generateImageFromPrompt('Draw me a horse drinking a coffee, in front of a fondita in Oaxaca', '1920-w');
+})->throws(\Asciito\SimpleGenerators\Clients\Exceptions\InvalidImageSize::class);

--- a/tests/Feature/Clients/OpenAIClientTest.php
+++ b/tests/Feature/Clients/OpenAIClientTest.php
@@ -51,7 +51,6 @@ it('generate an image with Open AI', function () {
 });
 
 test('invalid image size', function () {
-
     $openAI = new Client(clientResolver: fn () => new OpenAI\Testing\ClientFake());
 
     $openAI->generateImageFromPrompt('Draw me a horse drinking a coffee, in front of a fondita in Oaxaca', '1920-w');


### PR DESCRIPTION
A InvalidImageSize exception was added to handle invalid image sizes. In addition, all functions called generateImageFromPrompt now take an optional string argument for image size. This update also includes a test for invalid image sizes.